### PR TITLE
tput reset after cd

### DIFF
--- a/lib/atom-mac-terminal.js
+++ b/lib/atom-mac-terminal.js
@@ -10,7 +10,7 @@ function openTerminalTab(filePath) {
         '\n   activate' +
         '\n   my makeTab()' +
         '\n   set pathwithSpaces to "' + dir + '"' +
-        '\n   do script "cd " & quoted form of pathwithSpaces in front window' +
+        '\n   do script "cd " & quoted form of pathwithSpaces & "; tput reset" in front window' +
         '\n end tell' +
         '\n ' +
         '\n on makeTab()' +


### PR DESCRIPTION
This clears the screen so that the "cd $NEWPATH" doesn't get displayed.
